### PR TITLE
Fix: "Analyse on Lichess" button not loading game

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "vite-web-extension",
-  "version": "1.4.0",
+  "name": "lichess4chess",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "vite-web-extension",
-      "version": "1.4.0",
+      "name": "lichess4chess",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.9.0",

--- a/src/pages/content/gameState.ts
+++ b/src/pages/content/gameState.ts
@@ -37,7 +37,8 @@ export const detectGameState = (): GameState => {
   return GAME_STATE.NO_GAME_DETECTED;
 };
 
-export const getCurrentGamePgn = async (): Promise<string | null> => {  const shareButton = document.querySelector("[aria-label='Share']");
+export const getCurrentGamePgn = async (): Promise<string | null> => { 
+  const shareButton = document.querySelector("[aria-label='Share']");
   if (!shareButton) {
     throw new Error("Share button not found");
   }

--- a/src/pages/content/gameState.ts
+++ b/src/pages/content/gameState.ts
@@ -16,7 +16,8 @@ export const isGameFinished = (): boolean => {
   return (
     !!document.querySelector(".game-over-modal-content") ||
     !!document.querySelector(".game-over-modal") ||
-    !!document.querySelector(".share")
+    !!document.querySelector("[aria-label='Share']") ||
+    !!document.querySelector(".game-result")
   );
 };
 
@@ -36,7 +37,7 @@ export const detectGameState = (): GameState => {
   return GAME_STATE.NO_GAME_DETECTED;
 };
 
-export const getCurrentGamePgn = async (): Promise<string | null> => {  const shareButton = document.querySelector(".share");
+export const getCurrentGamePgn = async (): Promise<string | null> => {  const shareButton = document.querySelector("[aria-label='Share']");
   if (!shareButton) {
     throw new Error("Share button not found");
   }


### PR DESCRIPTION
# Pull Request

## 📝 Description

<!-- Provide a brief description of what this PR does -->
This PR fixes the **“Analyse on Lichess”** button issue in the **lichess4chess** Chrome extension.  
Previously, clicking the button on a chess.com game page opened the Lichess analysis board but never loaded the actual game data — the page stayed stuck on the loading screen indefinitely.  

The issue was caused by outdated DOM selectors (like `.share`) that no longer exist in chess.com’s updated structure.  
This fix updates the selectors and improves game completion detection, ensuring the game now loads correctly on Lichess and analysis begins automatically.

---

### Changes Made
<!-- List the main changes made in this PR -->
- Replaced obsolete `.share` selector with `[aria-label='Share']` to match the latest chess.com UI.
- Added `.game-result` selector to improve detection of finished games.
- Updated `isGameFinished()` to handle new DOM elements and reliably detect game completion.
- Updated `getCurrentGamePgn()` to correctly locate and extract the PGN from the updated “Share” button.
- Verified that “Analyse on Lichess” now loads the selected game correctly and initiates automatic analysis.
- Tested extension locally in the latest version of Chrome.

---

### Related Issues
<!-- Link any related issues using #issue_number -->
Fixes #8 

---

## 🎯 Type of Change

<!-- Mark the type of change with an [x] -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code style/formatting changes
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Build/CI changes
- [ ] Tests

---

## 📋 Checklist

<!-- Please check all applicable items -->
- [x] Pull request describes changes clearly
- [x] Builds locally (`npm run build`)
- [x] Tested extension with latest Chrome version
- [x] No console errors observed
- [x] Verified main functionality restored

---

## 🎥 Demo

<!-- If applicable, provide screenshots, GIFs, or video demonstrating the changes -->
The following demonstrates the fixed behavior:
1. Open any completed game on chess.com.
2. Click **"Analyse on Lichess"**.
3. The game loads successfully on Lichess and begins automatic analysis.


---




## 📋 Additional Notes

<!-- Any additional information that reviewers should know -->
- Tested extensively on multiple chess.com games.  
- No regressions observed in existing extension behavior.  
- All functionality now works as originally intended.
