### PR TITLE
Copy analysis URL

### DIFF
--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -159,5 +159,17 @@
   "suggestFeature": {
     "message": "Do you have a feature suggestion? Open an issue on GitHub :) I would be happy to implement it",
     "description": "Message for suggesting a feature"
+  },
+  "copyAnalysisUrl": {
+    "message": "Copy analysis URL",
+    "description": "Button to copy the Lichess analysis URL"
+  },
+  "copiedToClipboard": {
+    "message": "Copied to clipboard",
+    "description": "Feedback when URL is copied"
+  },
+  "failedToCopy": {
+    "message": "Failed to copy URL",
+    "description": "Feedback when copy fails"
   }
 }

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -1,5 +1,5 @@
 import Browser from 'webextension-polyfill';
-import { getCurrentState, initStateObserver, openLichessAnalysis } from './gameStateManager';
+import { getCurrentState, initStateObserver, openLichessAnalysis, getLichessAnalysisUrl } from './gameStateManager';
 
 const initialize = (): void => {
   initStateObserver();
@@ -11,6 +11,9 @@ const initialize = (): void => {
       
       case 'openLichessAnalysis':
         return openLichessAnalysis();
+      
+      case 'getLichessAnalysisUrl':
+        return getLichessAnalysisUrl().then(url => ({ url })).catch(err => ({ error: String(err) }));
       
       default:
         return false;


### PR DESCRIPTION
Adds a secondary button to the popup that imports the finished Chess.com game to Lichess and copies the resulting analysis URL to the clipboard. This improves sharing and lets users save the link without opening a new tab.

How It Works
When a game is finished, users can:
Click “Analyze on Lichess” (existing) to open analysis.
Click “Copy analysis URL” (new) to copy the analysis link directly to the clipboard.
Uses the same Lichess import flow as the open action; no new permissions required.
